### PR TITLE
Add For and RawImg components with path aliases

### DIFF
--- a/src/For.tsx
+++ b/src/For.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+interface ForProps<T> {
+  each: T[];
+  children: (item: T, index: number) => React.ReactNode;
+}
+
+export function For<T>({ each, children }: ForProps<T>) {
+  return (
+    <>
+      {each.map((item, index) => (
+        <React.Fragment key={index}>{children(item, index)}</React.Fragment>
+      ))}
+    </>
+  );
+}

--- a/src/components/For.tsx
+++ b/src/components/For.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+interface ForProps<T> {
+  each: T[];
+  children: (item: T, index: number) => React.ReactNode;
+}
+
+export function For<T>({ each, children }: ForProps<T>) {
+  return (
+    <>
+      {each.map((item, index) => (
+        <React.Fragment key={index}>{children(item, index)}</React.Fragment>
+      ))}
+    </>
+  );
+}

--- a/src/components/RawImg.tsx
+++ b/src/components/RawImg.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface RawImgProps {
+  image: string;
+  altText?: string;
+  css?: React.CSSProperties | Record<string, any>;
+  $name?: string;
+  className?: string;
+}
+
+export function RawImg({
+  image,
+  altText = "",
+  css = {},
+  $name,
+  className,
+  ...props
+}: RawImgProps) {
+  const imgStyle = {
+    ...css
+  };
+
+  return (
+    <img
+      src={image}
+      alt={altText}
+      style={imgStyle}
+      className={className}
+      data-name={$name}
+      {...props}
+    />
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,2 @@
+export { For } from "./For";
+export { RawImg } from "./RawImg";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export { For } from "./For";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "es6"
-    ],
+    "lib": ["dom", "dom.iterable", "es6"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -17,9 +13,12 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "paths": {
+      "@components": ["./components"],
+      "@components/*": ["./components/*"]
+    }
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Adds new reusable components and improves project structure:

- Creates For component for list iteration
- Adds RawImg component for image handling
- Sets up component exports in index.ts
- Configures TypeScript path aliases for @components
- Improves code organization with dedicated components folder

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d0a3c70828484479ae64c2321401e968/spark-works)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d0a3c70828484479ae64c2321401e968</projectId>-->